### PR TITLE
self_link is removed in favor of id.

### DIFF
--- a/modules/google-kms/keys.tf
+++ b/modules/google-kms/keys.tf
@@ -8,7 +8,7 @@ resource "google_kms_key_ring" "vault_key_ring" {
 # Create key to unseal Vault
 resource "google_kms_crypto_key" "vault_crypto_key" {
   name            = var.key_name
-  key_ring        = google_kms_key_ring.vault_key_ring.self_link
+  key_ring        = google_kms_key_ring.vault_key_ring.id
   rotation_period = "100000s"
 }
 


### PR DESCRIPTION
Resolves #2 

A side-note: after this change, I was able to spin up a Vault successfully, while ran into 2 hiccups:
- The NS record change propagation took more than 18 hours to take effect, would be better to note it in the documentation.
- The Vault UI worked as a charm after unsealing but the Vault CLI failed to connect to the Vault server with an error :

```
$ export VAULT_ADDR=https://vault.mydomain.com:8200
$ vault status
Error checking seal status: Get "https://vault.mydomain.com:8200/v1/sys/seal-status": x509: certificate signed by unknown authority
```

I'm still looking into it and suspecting if that's related to the CA of my certs. (wouldn't it be easier to update the Terraform to use GKE managed TLS in this case?)

Anyways, looks like this PR shall fix the aforementioned issue.